### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     name: Build & Test (ubuntu-latest.arm64)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/pjgrandinetti/OCTypes/security/code-scanning/4](https://github.com/pjgrandinetti/OCTypes/security/code-scanning/4)

To fix the problem, explicitly declare the minimal necessary permissions for the `build-arm64` job (line 192+), which is `contents: read` (so that the job can checkout the repo, etc.). This should be done by adding a `permissions:` block under the job definition in `.github/workflows/ci.yml`. 

- Add `permissions: contents: read` to the `build-arm64` job (typically as lines 194–195, indented to match other job fields).
- No additional imports, definitions, or methods are needed. No functional impact (as the job only needs to read code from the repository).
- Only changes are to the YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
