### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
   build-windows:
     name: Build & Test (windows-latest)
     runs-on: windows-latest
+    permissions:
+      contents: read
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/pjgrandinetti/OCTypes/security/code-scanning/3](https://github.com/pjgrandinetti/OCTypes/security/code-scanning/3)

To fix the problem and comply with the principle of least privilege, we should add an explicit `permissions:` block for the `build-windows` job (and ideally also for `build-core` and `build-macos`). However, the current CodeQL report is specifically about the `build-windows` job, so we will focus on resolving that as requested.

The minimum permission required by the build job is `contents: read`, which allows checkout of code and reading repository files. Steps like uploading artifacts do not require write permission to contents; they use the provided action hooks, which do not require extra `GITHUB_TOKEN` privileges. Therefore, we should add a block under `build-windows:`:

```yaml
permissions:
  contents: read
```

This block should be inserted at the same level as `runs-on` and `timeout-minutes` (i.e., above `steps:`).

**Change to make:**
- In `.github/workflows/ci.yml`, in the `build-windows` job, add a `permissions:` section with `contents: read` as the only permission.

No imports or extra definitions are required in YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
