### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
   build-macos:
     name: Build & Test (macos-latest)
     runs-on: macos-latest
+    permissions:
+      contents: read
     timeout-minutes: 25
     env:
       CCACHE_BASEDIR: ${{ github.workspace }}


### PR DESCRIPTION
Potential fix for [https://github.com/pjgrandinetti/OCTypes/security/code-scanning/2](https://github.com/pjgrandinetti/OCTypes/security/code-scanning/2)

To fix this issue, add an explicit `permissions` block to the `build-macos` job in `.github/workflows/ci.yml` with the minimally required privilege, which is `contents: read`.  
This is done by inserting the following under the job definition for `build-macos`—the same spot as already seen in `build-windows`—i.e., just after the `runs-on:` line and before any other keys at the same indentation level.  
No additional methods, imports, or variable definitions are required. Only a single-line YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
