### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
   build-core:
     name: Build & Test (ubuntu-latest.x64)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     env:
       CCACHE_BASEDIR: ${{ github.workspace }}


### PR DESCRIPTION
Potential fix for [https://github.com/pjgrandinetti/OCTypes/security/code-scanning/1](https://github.com/pjgrandinetti/OCTypes/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the `build-core` job to ensure the GITHUB_TOKEN is limited to the minimum required access. For a CI job that only checks out, builds, tests, and uploads artifacts, the job only needs `contents: read` permissions. Edit `.github/workflows/ci.yml`, and add the following lines to the `build-core` job, directly underneath the `runs-on` key (`line 24`):

```yaml
permissions:
  contents: read
```

This adds an explicit permissions block limiting token permissions, reducing possible attack surface and aligning with security recommendations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
